### PR TITLE
<feat>(download): resume if possible

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -168,7 +168,7 @@ function find-workspace {
 function get-setup {
   touch setup.ini
   mv setup.ini setup.ini-save
-  wget -N $mirror/$arch/setup.bz2
+  wget -cN $mirror/$arch/setup.bz2
   if [ -e setup.bz2 ]
   then
     bunzip2 setup.bz2
@@ -388,7 +388,7 @@ function download {
   cd "$cache/$mirrordir/$dn"
   if ! test -e $bn || ! $hash -c <<< "$digest $bn"
   then
-    wget -O $bn $mirror/$dn/$bn
+    wget -c -N -nd $mirror/$dn/$bn
     $hash -c <<< "$digest $bn" || exit
   fi
 


### PR DESCRIPTION
One doesn't want to restart the download of a several (hundred) MB file
only because of a net split during the last download with merely a few KB
missing, especially when using a slow connection or a connection were
such splits are normal...

Signed-off-by: Shea690901 <ginny690901@hotmail.de>